### PR TITLE
Update bpf-object-fuzzer.c

### DIFF
--- a/fuzz/bpf-object-fuzzer.c
+++ b/fuzz/bpf-object-fuzzer.c
@@ -1,23 +1,21 @@
 #include "libbpf.h"
 
-static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
-{
-	return 0;
-}
-
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	struct bpf_object *obj = NULL;
-	DECLARE_LIBBPF_OPTS(bpf_object_open_opts, opts);
-	int err;
+    struct bpf_object *obj = NULL;
+    int err;
 
-	libbpf_set_print(libbpf_print_fn);
+    // Open libbpf object from memory
+    obj = bpf_object__open_mem(data, size, NULL);
+    
+    // Check for errors
+    if (!obj) {
+        // Log or report error
+        return 0;
+    }
 
-	opts.object_name = "fuzz-object";
-	obj = bpf_object__open_mem(data, size, &opts);
-	err = libbpf_get_error(obj);
-	if (err)
-		return 0;
+    // Close the libbpf object
+    bpf_object__close(obj);
 
-	bpf_object__close(obj);
-	return 0;
+    return 0;
 }
+


### PR DESCRIPTION
 Here are some optimizations:

1)Remove Unnecessary Error Handling: Since the fuzzing harness is meant to test libbpf behavior, it might be unnecessary to handle errors in the fuzzing function. However, it's essential to log or report errors encountered during fuzzing to diagnose potential issues.

2)Simplify libbpf_print_fn: Since the current implementation of libbpf_print_fn does not print anything and always returns 0, we can remove it and let libbpf use its default print behavior.

3)Remove Redundant object_name Assignment: The object_name field is set to "fuzz-object", but it might not be necessary for fuzzing purposes. We can remove this assignment unless it's required for specific testing scenarios.

4)Combine Object Opening and Error Checking: Instead of separately calling bpf_object__open_mem and then checking for errors using libbpf_get_error, we can combine these steps and directly handle any errors returned by bpf_object__open_mem.

Thank you for considering a contribution!

Please note that the `libbpf` authoritative source code is developed as part of bpf-next Linux source tree under tools/lib/bpf subdirectory and is periodically synced to Github. As such, all the libbpf changes should be sent to BPF mailing list, please don't open PRs here unless you are changing Github-specific parts of libbpf (e.g., Github-specific Makefile).
